### PR TITLE
Don't include comments when grep'ing fstab

### DIFF
--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -291,7 +291,7 @@ fi
 # However, do not use the block device name in the kernel command line, as that is not consistently
 # named in booting normal and recovery modes. Expect fstab to have a system mountpoint or use a fallback.
 if [ "$USE_SYSTEM_PARTITION" -eq 1 ];then
-    SYSTEM_PARTITION=$(grep "/system" /etc/recovery.fstab |cut -f 1 -d\ )
+    SYSTEM_PARTITION=$(grep "^[^#]" /etc/recovery.fstab | grep "/system" | cut -f 1 -d\ )
     #Fall back to emmc@android if there's no system in fstab
     if [ "$SYSTEM_PARTITION" == "" ]; then
         SYSTEM_PARTITION = "emmc@android"


### PR DESCRIPTION
If for some reason recovery.fstab have a comment with /system in it, we
will crap out trying to format system as it will return start of the
comment.